### PR TITLE
Spawn one binder server for all the examples

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -24,7 +24,7 @@
       <div class="container">
         <div>
           <img src="bqplot-logo.svg" style="margin: 40px auto 40px auto; max-width: 400px; display: block;"/>
-          <h4 style="text-align: center">A gallery of bqplot dashboards</h4>
+          <h3 style="text-align: center">A gallery of bqplot dashboards</h3>
         </div>
       </div>
     </div>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -3,23 +3,16 @@ layout: default
 title: bqplot gallery
 ---
 
-<div class="modal fade" id="loading_modal" tabindex="-1" role="dialog" aria-labelledby="spinner">
-  <div class="modal-dialog modal-sm" role="document">
-    <div class="modal-content">
-      <div class="modal-body text-center">
-        <svg class="spinner" data-name="c1" version="1.1" viewBox="0 0 500 500" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"><metadata><rdf:RDF><cc:Work rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/><dc:title>voila</dc:title></cc:Work></rdf:RDF></metadata><title>spin</title><path class="bqplot-spinner-color1" d="m250 405c-85.47 0-155-69.53-155-155s69.53-155 155-155 155 69.53 155 155-69.53 155-155 155zm0-275.5a120.5 120.5 0 1 0 120.5 120.5 120.6 120.6 0 0 0-120.5-120.5z"/><path class="bqplot-spinner-color2" d="m250 405c-85.47 0-155-69.53-155-155a17.26 17.26 0 1 1 34.51 0 120.6 120.6 0 0 0 120.5 120.5 17.26 17.26 0 1 1 0 34.51z"/></svg>
-        <div id="loader_text"></div>
-      </div>
-    </div>
-  </div>
-</div>
-
 <div class="row no-gutters">
   {% for example in site.data.gallery %}
   <div class="col-md-4" style="height: 400px; padding: 16px;">
     <input type="radio" name="example" id="example-{{ example.name }}" value="{{ example.name }}" class="d-none" />
     <div class="gallery-item">
-      <div class="launch-item" style="height: 90%; padding: 8px;" id="example-{{ example.name }}"
+      <div class="text-center spinner-container">
+        <svg class="spinner" data-name="c1" version="1.1" viewBox="0 0 500 500" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"><metadata><rdf:RDF><cc:Work rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/><dc:title>voila</dc:title></cc:Work></rdf:RDF></metadata><title>spin</title><path class="bqplot-spinner-color1" d="m250 405c-85.47 0-155-69.53-155-155s69.53-155 155-155 155 69.53 155 155-69.53 155-155 155zm0-275.5a120.5 120.5 0 1 0 120.5 120.5 120.6 120.6 0 0 0-120.5-120.5z"/><path class="bqplot-spinner-color2" d="m250 405c-85.47 0-155-69.53-155-155a17.26 17.26 0 1 1 34.51 0 120.6 120.6 0 0 0 120.5 120.5 17.26 17.26 0 1 1 0 34.51z"/></svg>
+        <div class="loader_text">We are spawning a Binder server for you, please stand by</div>
+      </div>
+      <div class="launch-item disabled" style="height: 90%; padding: 8px;" id="example-{{ example.name }}"
            data-example-name="{{ example.title }}"
            data-example-url="{{ example.url }}"
       >

--- a/css/style.css
+++ b/css/style.css
@@ -46,21 +46,18 @@ body {
   user-select: none;
   border: 2px solid #252525;
   border-radius: 0.25rem;
+  opacity: 1;
+  transition: opacity 1s ease-in-out;
 }
 
 .gallery-item:hover {
   box-shadow: 4px 4px 12px #252525;
   cursor: pointer;
-  transition: box-shadow 0.3s ease-in-out;
+  transition: box-shadow 0.2s ease-in-out;
 }
 
-.modal-content {
-  border-radius: 0px;
-  box-shadow: 0 0 20px 8px #252525;
-}
-
-.modal-backdrop.show {
-  opacity: 0.75;
+.gallery-item > .disabled {
+  opacity: 0.2;
 }
 
 #loading_text {
@@ -78,13 +75,18 @@ body {
   text-align: center;
 }
 
+.spinner-container {
+  z-index: 200;
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translateY(-50%) translateX(-50%);
+}
+
 .spinner {
   animation: rotation 2s infinite linear;
   transform-origin: 50% 50%;
-}
-
-.spinner-container {
-  width: 100%;
+  width: 100px;
 }
 
 @keyframes rotation {

--- a/js/index.js
+++ b/js/index.js
@@ -1,34 +1,29 @@
 $(document).ready(function() {
-  var BUILD_ENDPOINT = BINDERHUB_HOST + '/build/gh';
+  var binderUrl = null;
+  var token = null;
+
+  var buildUrl = BINDERHUB_HOST + '/build/gh/bqplot/bqplot-gallery/main';
+  var evtSource = new EventSource(buildUrl);
+  evtSource.onmessage = function(event) {
+    var data = JSON.parse(event.data);
+    $('#loader_text').html(data.phase);
+    console.log(data.message);
+    if (data.phase === 'ready') {
+      evtSource.close();
+      binderUrl = data.url;
+      token = data.token;
+
+      $('.launch-item.disabled').removeClass("disabled");
+      $('.spinner-container').remove();
+    }
+  };
 
   $('.launch-item').click(function(event) {
-    var name = $(event.currentTarget).data('example-name');
-    var url = $(event.currentTarget).data('example-url');
-    var ref = 'main';
+    if (binderUrl !== null) {
+      var url = $(event.currentTarget).data('example-url');
 
-    $('#loading_modal').modal({
-      backdrop: 'static',
-      keyboard: false,
-      show: true
-    });
-
-    $('#loader_text').html('Launching ' + name);
-
-    var buildUrl = BUILD_ENDPOINT + '/bqplot/bqplot-gallery/' + ref + '?urlpath=voila/render/' + url;
-    var evtSource = new EventSource(buildUrl);
-    evtSource.onmessage = function(event) {
-      var data = JSON.parse(event.data);
-      $('#loader_text').html(data.phase);
-      console.log(data.message);
-      if (data.phase === 'ready') {
-        evtSource.close();
-        var redirectUrl = data.url;
-        var token = data.token;
-        var redirect = redirectUrl + 'voila/render/' + url + '?token=' + token;
-        $('#loader_text').html('Launching');
-        window.location.href = redirect;
-      }
-    };
-    return false;
+      var voilaUrl = binderUrl + 'voila/render/' + url + '?token=' + token;
+      window.open(voilaUrl, '_blank').focus();
+    }
   });
 });


### PR DESCRIPTION
This improves the UX so that the user can see all examples quicker, it will also reduce the load on binderhub

https://user-images.githubusercontent.com/21197331/150761865-09eca0ac-3623-4a78-9c3f-e6a7fa0804f6.mp4